### PR TITLE
change absolute path reference to relative path reference

### DIFF
--- a/OTIPChanger/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/OTIPChanger/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>C:\Users\Nekiro\Documents\repos\OTIPChanger\out</PublishDir>
+    <PublishDir>out</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>


### PR DESCRIPTION
change the absolute path reference inside the `PublishDir` tag to a relative path reference with respect to the project's root directory